### PR TITLE
[Port] 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,11 +12,11 @@ org.gradle.daemon=true
 org.gradle.warning.mode = all
 
 # Check these on https://fabricmc.net/versions.html
-minecraftVersion = 26.1
-loaderVersion = 0.18.4
+minecraftVersion = 26.2-pre-1
+loaderVersion = 0.19.2
 
 # Fabric API
-fabricVersion = 0.144.0+26.1
+fabricVersion = 0.149.2+26.2
 loomVersion = 1.15-SNAPSHOT
 
 # Kotlin
@@ -25,7 +25,7 @@ fabricKotlinVersion = 1.13.9+kotlin.2.3.10
 tomlktVersion = 0.3.7
 janksonVersion = 1.2.3
 fabricPermsVersion = 0.7.0
-modmenuVersion = 18.0.0-alpha.6
+modmenuVersion = 19.0.0-alpha.1
 
 # Uploading
 mcVersions = 26.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,18 +17,18 @@ loaderVersion = 0.19.2
 
 # Fabric API
 fabricVersion = 0.149.2+26.2
-loomVersion = 1.15-SNAPSHOT
+loomVersion = 1.16-SNAPSHOT
 
 # Kotlin
-systemProp.kotlinVersion = 2.3.10
-fabricKotlinVersion = 1.13.9+kotlin.2.3.10
+systemProp.kotlinVersion = 2.3.21
+fabricKotlinVersion = 1.13.11+kotlin.2.3.21
 tomlktVersion = 0.3.7
 janksonVersion = 1.2.3
 fabricPermsVersion = 0.7.0
 modmenuVersion = 19.0.0-alpha.1
 
 # Uploading
-mcVersions = 26.1
+mcVersions = 26.2
 mcCurseVersions =
 uploadDebugMode = false
 releaseType = release

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/config/ConfigAction.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/config/ConfigAction.kt
@@ -325,12 +325,12 @@ class ConfigAction @JvmOverloads constructor(
                     val uRI = clickEvent.uri()
                     if (!client.options.chatLinksPrompt().get()) return false
                     if (client.options.chatLinksPrompt().get()) {
-                        val screen = client.screen
-                        client.setScreen(ConfirmLinkScreen({ confirmed: Boolean ->
+                        val screen = client.gui.screen()
+                        client.gui.setScreen(ConfirmLinkScreen({ confirmed: Boolean ->
                             if (confirmed) {
                                 Util.getPlatform().openUri(uRI)
                             }
-                            client.setScreen(screen)
+                            client.gui.setScreen(screen)
                         }, uRI.toString(), false))
                     } else {
                         Util.getPlatform().openUri(uRI)
@@ -357,7 +357,7 @@ class ConfigAction @JvmOverloads constructor(
                 return true
             } else if (clickEvent is ClickEvent.ShowDialog) {
                 val player = client.player ?: return false
-                player.connection.showDialog(clickEvent.dialog(), client.screen)
+                player.connection.showDialog(clickEvent.dialog(), client.gui.screen())
                 return true
             } else if (clickEvent is ClickEvent.Custom) {
                 val player = client.player ?: return false

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/entry/EntryAnchor.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/entry/EntryAnchor.kt
@@ -96,7 +96,7 @@ interface EntryAnchor {
             override fun action(scope: String, anchorId: String): Runnable {
                 return Runnable {
                     ConfigApi.openScreen(scope)
-                    Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.scrollToGroup(anchorId)
+                    Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.scrollToGroup(anchorId)
                 }
             }
         };

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/examples/MinecraftExamples.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/examples/MinecraftExamples.kt
@@ -21,7 +21,7 @@ object MinecraftExamples {
 
     fun tags() {
         //validated block tag that allows any tag in the Block Registry
-        val validatedTag = ValidatedTagKey(BlockTags.ACACIA_LOGS)
+        val validatedTag = ValidatedTagKey(BlockTags.LOGS)
 
         //validated Item TagKey with a predicate on the various tool types (this is optional)
         val validatedTagPredicated = ValidatedTagKey(ItemTags.AXES) { id ->

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/impl/ConfigApiImplClient.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/impl/ConfigApiImplClient.kt
@@ -87,10 +87,10 @@ internal object ConfigApiImplClient {
     }
 
     internal fun openRestartScreen(): Boolean {
-        if (Minecraft.getInstance().screen is RestartScreen) return false
+        if (Minecraft.getInstance().gui.screen() is RestartScreen) return false
         Minecraft.getInstance().execute {
-            if (Minecraft.getInstance().screen !is RestartScreen)
-                Minecraft.getInstance().setScreen(RestartScreen())
+            if (Minecraft.getInstance().gui.screen() !is RestartScreen)
+                Minecraft.getInstance().gui.setScreen(RestartScreen())
         }
         return true
     }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/ConfigScreenProvider.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/ConfigScreenProvider.kt
@@ -46,7 +46,7 @@ fun interface ConfigScreenProvider {
      */
     fun openScreen(namespace: String, scope: String): Boolean {
         val screen = provideScreen(namespace, scope) ?: return false
-        Minecraft.getInstance().setScreen(screen)
+        Minecraft.getInstance().gui.setScreen(screen)
         return true
     }
 }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/PopupController.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/PopupController.kt
@@ -186,7 +186,7 @@ interface PopupController: LastSelectable {
         }
 
         internal fun pop() {
-            val popupParentElement = Minecraft.getInstance().screen?.nullCast<PopupController>() ?: return
+            val popupParentElement = Minecraft.getInstance().gui.screen()?.nullCast<PopupController>() ?: return
             popupParentElement.setPopupInternal(null, null, null)
         }
 

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/context/Position.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/context/Position.kt
@@ -50,8 +50,8 @@ data class Position(val contextInput: ContextInput,
                 mX.toInt(), mY.toInt(),
                 widget.x, widget.y,
                 widget.width, widget.height,
-                Minecraft.getInstance()?.screen?.width ?: widget.width,
-                Minecraft.getInstance()?.screen?.height ?: widget.height)
+                Minecraft.getInstance().gui.screen()?.width ?: widget.width,
+                Minecraft.getInstance().gui.screen()?.height ?: widget.height)
         }
     }
 }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/entry/EntryCreators.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/entry/EntryCreators.kt
@@ -78,7 +78,7 @@ object EntryCreators {
                     "open_screen",
                     CustomButtonWidget.builder(context.texts.name) {
                         if (SearchConfig.INSTANCE.willPassSearch()) {
-                            val search = Minecraft.getInstance().screen.nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
+                            val search = Minecraft.getInstance().gui.screen().nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
                             if (search.isNotEmpty()) {
                                 val scope = "${context.scope}.::$search"
                                 context.misc.get(OPEN_SCREEN)?.accept(scope)
@@ -112,7 +112,7 @@ object EntryCreators {
                     "open_screen",
                     CustomButtonWidget.builder(context.texts.name) {
                         if (SearchConfig.INSTANCE.willPassSearch()) {
-                            val search = Minecraft.getInstance().screen.nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
+                            val search = Minecraft.getInstance().gui.screen().nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
                             if (search.isNotEmpty()) {
                                 val scope = "${context.scope}.::$search"
                                 context.misc.get(OPEN_SCREEN)?.accept(scope)

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/ConfigScreen.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/ConfigScreen.kt
@@ -147,9 +147,9 @@ internal class ConfigScreen(
     override fun onClose() {
         if(this.parent == null || this.parent !is ConfigScreen) {
             onFinalClose.run()
-            this.minecraft?.narrator?.clear()
+            this.minecraft.narrator.clear()
         }
-        this.minecraft?.setScreen(parent)
+        this.minecraft.gui.setScreen(parent)
     }
 
     private fun shiftClose() {

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/ConfigScreenManager.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/ConfigScreenManager.kt
@@ -161,7 +161,7 @@ internal class ConfigScreenManager(private val scope: String, private val subSco
     }
 
     internal fun isScreenOpen(scope: String): Boolean {
-        return Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.scope?.let {
+        return Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.scope?.let {
             //perfect scope match or the root config is open and the scope alias lines up
             it == scope || (it == rootScope && scope == this.scope || scope == this.rootScope)
         } == true
@@ -189,7 +189,7 @@ internal class ConfigScreenManager(private val scope: String, private val subSco
             cachedPermKey.incrementAndGet()
         }
         //don't open the screen that's already open
-        if (Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.scope?.let {
+        if (Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.scope?.let {
             //perfect scope match or the root config is open and the scope alias lines up
             it == scope || (it == rootScope && scope == this.scope || scope == this.rootScope)
         } == true) {
@@ -204,7 +204,7 @@ internal class ConfigScreenManager(private val scope: String, private val subSco
         try {
             val screenArgPair = provideScopedScreen(scope)
             val screen = screenArgPair.first ?: return
-            Minecraft.getInstance().setScreen(screenArgPair.first)
+            Minecraft.getInstance().gui.setScreen(screenArgPair.first)
             val rawEntryString = screenArgPair.second
             if (rawEntryString != null && rawEntryString != "") {
                 screen.scrollToEntry(scope)
@@ -554,7 +554,7 @@ internal class ConfigScreenManager(private val scope: String, private val subSco
                     if (cache.manager.hasChanges()) cache.manager.apply(true)
                     cache.manager.invalidatePush()
                 }
-            }.setParent(Minecraft.getInstance().screen)
+            }.setParent(Minecraft.getInstance().gui.screen())
         }
     }
 

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/SuggestionWindow.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/internal/SuggestionWindow.kt
@@ -188,8 +188,8 @@ class SuggestionWindow(
             for (suggestion in suggestions.list) {
                 w = max(w, Minecraft.getInstance().font.width(suggestion.text))
             }
-            val sWidth = Minecraft.getInstance().screen?.width ?: Int.MAX_VALUE
-            val sHeight = Minecraft.getInstance().screen?.height ?: Int.MAX_VALUE
+            val sWidth = Minecraft.getInstance().gui.screen()?.width ?: Int.MAX_VALUE
+            val sHeight = Minecraft.getInstance().gui.screen()?.height ?: Int.MAX_VALUE
             val x = max(min(windowX, sWidth - w), 0)
             var h = min(suggestions.list.size * 12, 120)
             val down = sHeight - (windowY + 20)

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/DynamicListWidget.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/DynamicListWidget.kt
@@ -296,7 +296,7 @@ class DynamicListWidget(
 
     override fun extractWidgetRenderState(context: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
         super.extractWidgetRenderState(context, mouseX, mouseY, delta)
-        context.enableScissor(0, this.top, Minecraft.getInstance().screen?.width ?: 320, this.bottom)
+        context.enableScissor(0, this.top, Minecraft.getInstance().gui.screen()?.width ?: 320, this.bottom)
         for (entry in inFrameEntries()) {
             entry.renderExtras(context, mouseX, mouseY, delta)
         }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/PopupWidget.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/PopupWidget.kt
@@ -275,7 +275,7 @@ class PopupWidget
          */
         @JvmOverloads
         fun push(popup: PopupWidget?, mouseX: Double? = null, mouseY: Double? = null) {
-            Minecraft.getInstance().screen?.nullCast<PopupParentElement>()?.setPopup(popup, mouseX, mouseY)
+            Minecraft.getInstance().gui.screen()?.nullCast<PopupParentElement>()?.setPopup(popup, mouseX, mouseY)
         }
 
         /**
@@ -308,7 +308,7 @@ class PopupWidget
          */
         @JvmOverloads
         fun pushImmediate(popup: PopupWidget?, mouseX: Double? = null, mouseY: Double? = null) {
-            Minecraft.getInstance().screen?.nullCast<PopupParentElement>()?.setPopupImmediate(popup, mouseX, mouseY)
+            Minecraft.getInstance().gui.screen()?.nullCast<PopupParentElement>()?.setPopupImmediate(popup, mouseX, mouseY)
         }
 
         /**
@@ -331,7 +331,7 @@ class PopupWidget
          * @since 0.2.0
          */
         fun focusElement(element: GuiEventListener) {
-            (Minecraft.getInstance().screen as? PopupWidgetScreen)?.popupWidgets?.peek()?.trySetFocused(element)
+            (Minecraft.getInstance().gui.screen() as? PopupWidgetScreen)?.popupWidgets?.peek()?.trySetFocused(element)
         }
 
         /**

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/SuggestionBackedTextFieldWidget.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/screen/widget/SuggestionBackedTextFieldWidget.kt
@@ -114,7 +114,7 @@ class SuggestionBackedTextFieldWidget(
             }
         }
         if (window != null)
-            Minecraft.getInstance().screen?.nullCast<PopupController>()?.suggestionWindow = window
+            Minecraft.getInstance().gui.screen()?.nullCast<PopupController>()?.suggestionWindow = window
     }
 
     private fun addSuggestionWindow(suggestions: Suggestions) {
@@ -136,7 +136,7 @@ class SuggestionBackedTextFieldWidget(
         if (closeWindow) {
             pendingSuggestions = null
             window = null
-            Minecraft.getInstance().screen?.nullCast<PopupController>()?.suggestionWindow = null
+            Minecraft.getInstance().gui.screen()?.nullCast<PopupController>()?.suggestionWindow = null
             suggestionWindowListener?.setSuggestionWindowElement(null)
             closeWindow = false
         }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/FcText.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/FcText.kt
@@ -11,8 +11,8 @@
 package me.fzzyhmstrs.fzzy_config.util
 
 import com.mojang.brigadier.Message
+import me.fzzyhmstrs.fzzy_config.util.PortingUtils.langKeyExists
 import net.minecraft.client.gui.Font
-import net.minecraft.client.resources.language.I18n
 import net.minecraft.network.chat.CommonComponents
 import net.minecraft.ChatFormatting
 import net.minecraft.resources.Identifier
@@ -288,7 +288,7 @@ object FcText {
                 return this.prefix()
             }
         }
-        return if (I18n.exists(fallback))
+        return if (langKeyExists(fallback))
             translatable(fallback).withStyle(ChatFormatting.ITALIC)
         else
             null

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/PortingUtils.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/PortingUtils.kt
@@ -32,6 +32,7 @@ import net.minecraft.resources.Identifier
 import net.minecraft.util.ARGB
 import java.util.*
 import java.util.function.Predicate
+import net.minecraft.locale.Language
 
 object PortingUtils {
 
@@ -119,6 +120,10 @@ object PortingUtils {
 
     fun isControlDown(): Boolean {
         return Minecraft.getInstance().hasControlDown()
+    }
+
+    fun langKeyExists(key:String): Boolean {
+        return Language.getInstance().has(key)
     }
 
     object Codecs {

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/Translatable.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/Translatable.kt
@@ -17,7 +17,7 @@ import me.fzzyhmstrs.fzzy_config.api.ConfigApi
 import me.fzzyhmstrs.fzzy_config.api.ConfigApiJava
 import me.fzzyhmstrs.fzzy_config.util.FcText.transSupplied
 import me.fzzyhmstrs.fzzy_config.util.FcText.translate
-import net.minecraft.client.resources.language.I18n
+import me.fzzyhmstrs.fzzy_config.util.PortingUtils.langKeyExists
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Component
 import net.minecraft.ChatFormatting
@@ -129,7 +129,7 @@ interface Translatable {
      * @since 0.2.8
      */
     fun hasTranslation(): Boolean {
-        return I18n.exists(translationKey())
+        return langKeyExists(translationKey())
     }
     /**
      * Whether this Translatable has a valid description
@@ -138,7 +138,7 @@ interface Translatable {
      * @since 0.2.8
      */
     fun hasDescription(): Boolean {
-        return I18n.exists(descriptionKey())
+        return langKeyExists(descriptionKey())
     }
     /**
      * Whether this Translatable has a valid prefix
@@ -147,7 +147,7 @@ interface Translatable {
      * @since 0.6.0
      */
     fun hasPrefix(): Boolean {
-        return I18n.exists(prefixKey())
+        return langKeyExists(prefixKey())
     }
 
     object Impls {
@@ -192,9 +192,9 @@ interface Translatable {
             val keyN = if(bl) FcText.concat(annotation.prefix, PERIOD, fieldName) else annotation.prefix
             val keyD = if(bl) FcText.concat(annotation.prefix, PERIOD, fieldName, DESC) else FcText.concat(annotation.prefix, DESC)
             val keyP = if(bl) FcText.concat(annotation.prefix, PERIOD, fieldName, PREFIX) else FcText.concat(annotation.prefix, PREFIX)
-            val n = if (I18n.exists(keyN)) keyN.translate() else thing.transSupplied { getNameFallback(annotations, fallback) }
-            val d = if (I18n.exists(keyD)) keyD.translate() else thing.descGet { getDescFallback(annotations, globalAnnotations) }
-            val p = if (I18n.exists(keyP)) keyP.translate() else thing.prefixGet { getPrefixFallback(annotations) }
+            val n = if (langKeyExists(keyN)) keyN.translate() else thing.transSupplied { getNameFallback(annotations, fallback) }
+            val d = if (langKeyExists(keyD)) keyD.translate() else thing.descGet { getDescFallback(annotations, globalAnnotations) }
+            val p = if (langKeyExists(keyP)) keyP.translate() else thing.prefixGet { getPrefixFallback(annotations) }
             return Utils.createScopedResult(scope, n, d, p)
         }
 

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/RegistrySupplier.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/RegistrySupplier.kt
@@ -19,7 +19,7 @@ import java.util.stream.Stream
  * @author fzzyhmstrs
  * @since 0.5.9, implements RegistryEntry itself as of 0.6.5, no longer experimental 0.7.0
  */
-interface RegistrySupplier<T: Any>: Supplier<T>, Holder<T> {
+interface RegistrySupplier<T: Any>: Supplier<T> {
 
     /**
      * The objects [RegistryKey]
@@ -47,53 +47,53 @@ interface RegistrySupplier<T: Any>: Supplier<T>, Holder<T> {
 
     /////// Implementation of RegistryEntry ///////
 
-    override fun isBound(): Boolean {
+    fun isBound(): Boolean {
         return getEntry().isBound
     }
 
-    override fun `is`(id: Identifier): Boolean {
+    fun `is`(id: Identifier): Boolean {
         return getEntry().`is`(id)
     }
 
-    override fun `is`(key: ResourceKey<T>): Boolean {
+    fun `is`(key: ResourceKey<T>): Boolean {
         return getEntry().`is`(key)
     }
 
-    override fun `is`(predicate: Predicate<ResourceKey<T>>): Boolean {
+    fun `is`(predicate: Predicate<ResourceKey<T>>): Boolean {
         return getEntry().`is`(predicate)
     }
 
-    override fun `is`(tag: TagKey<T>): Boolean {
+    fun `is`(tag: TagKey<T>): Boolean {
         return getEntry().`is`(tag)
     }
 
-    override fun tags(): Stream<TagKey<T>> {
+    fun tags(): Stream<TagKey<T>> {
         return getEntry().tags()
     }
 
-    override fun unwrap(): Either<ResourceKey<T>, T> {
+    fun unwrap(): Either<ResourceKey<T>, T> {
         return getEntry().unwrap()
     }
 
-    override fun unwrapKey(): Optional<ResourceKey<T>> {
+    fun unwrapKey(): Optional<ResourceKey<T>> {
         return getEntry().unwrapKey()
     }
 
-    override fun kind(): Holder.Kind {
+    fun kind(): Holder.Kind {
         return getEntry().kind()
     }
 
-    override fun canSerializeIn(owner: HolderOwner<T>): Boolean {
+    fun canSerializeIn(owner: HolderOwner<T>): Boolean {
         return getEntry().canSerializeIn(owner)
     }
 
     @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated("Deprecated in Java")
-    override fun `is`(entry: Holder<T>): Boolean {
+    fun `is`(entry: Holder<T>): Boolean {
         return getEntry().`is`(entry)
     }
 
-    override fun value(): T {
+    fun value(): T {
         return get()
     }
 }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/impl/RegistryBuilderImpl.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/impl/RegistryBuilderImpl.kt
@@ -3,11 +3,9 @@ package me.fzzyhmstrs.fzzy_config.util.platform.impl
 import com.mojang.serialization.Codec
 import com.mojang.serialization.DataResult
 import com.mojang.serialization.Lifecycle
-import me.fzzyhmstrs.fzzy_config.cast
 import me.fzzyhmstrs.fzzy_config.nsId
 import me.fzzyhmstrs.fzzy_config.simpleId
 import me.fzzyhmstrs.fzzy_config.util.platform.RegistryBuilder
-import me.fzzyhmstrs.fzzy_config.util.platform.RegistrySupplier
 import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab
 import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder
 import net.minecraft.world.item.CreativeModeTab
@@ -74,7 +72,7 @@ class RegistryBuilderImpl(private val namespace: String): RegistryBuilder {
     }
 
     override fun <T: Any> regSupplierCodec(registry: Registry<T>): Codec<Holder<T>> {
-        return registry.holderByNameCodec().xmap(Function.identity()) { re -> if (re is RegistrySupplier<T>) re.getEntry().cast() else re }
+        return registry.holderByNameCodec()
     }
 
     override fun <T: Any> referenceEntryCodec(registry: Registry<T>): Codec<Reference<T>> {

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/impl/RegistrySupplierImpl.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/util/platform/impl/RegistrySupplierImpl.kt
@@ -13,11 +13,11 @@ internal class RegistrySupplierImpl<T: Any>(private val entry: Holder.Reference<
         return entry.key()
     }
 
-    override fun areComponentsBound(): Boolean {
+    fun areComponentsBound(): Boolean {
         return entry.areComponentsBound()
     }
 
-    override fun components(): DataComponentMap {
+    fun components(): DataComponentMap {
         return entry.components()
     }
 

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/minecraft/ValidatedIdentifier.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/minecraft/ValidatedIdentifier.kt
@@ -1195,7 +1195,7 @@ open class ValidatedIdentifier @JvmOverloads constructor(defaultValue: Identifie
                 }
             }
             if (window != null)
-                Minecraft.getInstance().screen?.nullCast<PopupController>()?.suggestionWindow = window
+                Minecraft.getInstance().gui.screen()?.nullCast<PopupController>()?.suggestionWindow = window
         }
 
         override fun mouseClicked(click: MouseButtonEvent, doubled: Boolean): Boolean {
@@ -1222,7 +1222,7 @@ open class ValidatedIdentifier @JvmOverloads constructor(defaultValue: Identifie
             if (closeWindow) {
                 pendingSuggestions = null
                 window = null
-                Minecraft.getInstance().screen?.nullCast<PopupController>()?.suggestionWindow = null
+                Minecraft.getInstance().gui.screen()?.nullCast<PopupController>()?.suggestionWindow = null
                 suggestionWindowListener?.setSuggestionWindowElement(null)
                 closeWindow = false
             }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/minecraft/ValidatedIdentifier.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/minecraft/ValidatedIdentifier.kt
@@ -60,6 +60,7 @@ import net.minecraft.ChatFormatting
 import net.minecraft.core.HolderLookup
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.network.chat.TextColor
 import net.minecraft.resources.Identifier
 import net.minecraft.resources.RegistryDataLoader
 import net.minecraft.resources.ResourceKey
@@ -1128,7 +1129,7 @@ open class ValidatedIdentifier @JvmOverloads constructor(defaultValue: Identifie
             }
             val id = Identifier.tryParse(s)
             if (id == null || !s.contains(":")) {
-                setTextColor(ARGB.opaque(ChatFormatting.RED.color ?: 0xFFFFFF))
+                setTextColor(ARGB.opaque(TextColor.fromLegacyFormat(ChatFormatting.RED)?.value ?: 0xFFFFFF))
                 return false
             }
             return if (validatedIdentifier.validateEntry(id, EntryValidator.ValidationType.STRONG).isValid()) {
@@ -1139,11 +1140,11 @@ open class ValidatedIdentifier @JvmOverloads constructor(defaultValue: Identifie
                     setTextColor(-1)
                     true
                 } else {
-                    setTextColor(ARGB.opaque(ChatFormatting.RED.color ?: 0xFFFFFF))
+                    setTextColor(ARGB.opaque(TextColor.RED.value))
                     false
                 }
             } else {
-                setTextColor(ARGB.opaque(ChatFormatting.RED.color ?: 0xFFFFFF))
+                setTextColor(ARGB.opaque(TextColor.RED.value))
                 false
             }
         }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedAny.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedAny.kt
@@ -312,7 +312,7 @@ open class ValidatedAny<T: Any>(defaultValue: T): ValidatedField<T>(defaultValue
         }
         searchField.setMaxLength(100)
         val searchText = if (SearchConfig.INSTANCE.willPassSearch()) {
-            Minecraft.getInstance().screen.nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
+            Minecraft.getInstance().gui.screen().nullCast<ConfigScreen>()?.getCurrentSearch() ?: ""
         } else {
             ""
         }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedColor.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedColor.kt
@@ -54,6 +54,7 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.DyeColor
 import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.TextColor
 import net.minecraft.util.Mth
 import net.peanuuutz.tomlkt.*
 import org.jetbrains.annotations.ApiStatus.Internal
@@ -225,11 +226,11 @@ open class ValidatedColor: ValidatedField<ColorHolder>, EntryOpener {
      * @since 0.7.2
      */
     fun withFormattingColorPresets(): ValidatedColor {
-        val colors = ChatFormatting.entries.mapNotNull { it.takeIf { it.color != null } }
+        val colors = ChatFormatting.entries.mapNotNull { it.takeIf { TextColor.fromLegacyFormat(it)?.value != null } }
         return withColorPresets(if (get().opaque()) colors.map {
-            ColorPreset(it.color!!, get().alphaMode, it.name.capital())
+            ColorPreset(TextColor.fromLegacyFormat(it)?.value!!, get().alphaMode, it.name.capital())
         } else colors.map {
-            ColorPreset(PortingUtils.fullAlpha(it.color!!), get().alphaMode, it.name.capital())
+            ColorPreset(PortingUtils.fullAlpha(TextColor.fromLegacyFormat(it)?.value!!), get().alphaMode, it.name.capital())
         })
     }
 

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedKeybind.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/misc/ValidatedKeybind.kt
@@ -308,7 +308,7 @@ open class ValidatedKeybind(defaultValue: FzzyKeybind): ValidatedField<FzzyKeybi
                 }
                 resetting = false
                 compounding = false
-                Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.setGlobalInputHandler(null)
+                Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.setGlobalInputHandler(null)
             }
         }
 
@@ -323,7 +323,7 @@ open class ValidatedKeybind(defaultValue: FzzyKeybind): ValidatedField<FzzyKeybi
         }
 
         fun setupHandler() {
-            Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.setGlobalInputHandler { key, released, type, ctrl, shift, alt ->
+            Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.setGlobalInputHandler { key, released, type, ctrl, shift, alt ->
                 if (!released || justCLickedToggle || justClickedShift) {
                     if (released && (key == GLFW.GLFW_KEY_LEFT_SHIFT || key == GLFW.GLFW_KEY_RIGHT_SHIFT)) {
                         justClickedShift = false
@@ -346,7 +346,7 @@ open class ValidatedKeybind(defaultValue: FzzyKeybind): ValidatedField<FzzyKeybi
                 }
                 resetting = false
                 compounding = false
-                Minecraft.getInstance().screen?.nullCast<ConfigScreen>()?.setGlobalInputHandler(null)
+                Minecraft.getInstance().gui.screen()?.nullCast<ConfigScreen>()?.setGlobalInputHandler(null)
                 TriState.TRUE
             }
         }

--- a/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/number/ValidatedNumber.kt
+++ b/src/main/kotlin/me/fzzyhmstrs/fzzy_config/validation/number/ValidatedNumber.kt
@@ -22,6 +22,7 @@ import me.fzzyhmstrs.fzzy_config.simpleId
 import me.fzzyhmstrs.fzzy_config.util.FcText
 import me.fzzyhmstrs.fzzy_config.util.FcText.lit
 import me.fzzyhmstrs.fzzy_config.util.FcText.translate
+import me.fzzyhmstrs.fzzy_config.util.PortingUtils.langKeyExists
 import me.fzzyhmstrs.fzzy_config.util.RenderUtil.drawTex
 import me.fzzyhmstrs.fzzy_config.util.ValidationResult
 import me.fzzyhmstrs.fzzy_config.util.ValidationResult.Companion.attachTo
@@ -35,10 +36,8 @@ import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.narration.NarrationElementOutput
 import net.minecraft.client.gui.narration.NarratedElementType
 import net.minecraft.client.gui.components.AbstractWidget
-import net.minecraft.client.resources.language.I18n
 import net.minecraft.client.sounds.SoundManager
 import net.minecraft.network.chat.MutableComponent
-import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
 import net.minecraft.util.Util
 import net.minecraft.util.Mth
@@ -110,7 +109,7 @@ sealed class ValidatedNumber<T>(defaultValue: T, protected val minValue: T, prot
 
     @Internal
     override fun description(fallback: String?): MutableComponent {
-        return if(I18n.exists(descriptionKey())) super.description(fallback) else genericDescription()
+        return if(langKeyExists(descriptionKey())) super.description(fallback) else genericDescription()
     }
 
     private fun genericDescription(): MutableComponent {

--- a/src/testmod/kotlin/me/fzzyhmstrs/fzzy_config_test/fzzy_config_test.kt
+++ b/src/testmod/kotlin/me/fzzyhmstrs/fzzy_config_test/fzzy_config_test.kt
@@ -251,7 +251,7 @@ object FCC: ClientModInitializer {
         }
         ClientTickEvents.START_CLIENT_TICK.register{client ->
             if (openDamnScreen == "please") {
-                client.setScreen(TestPopupScreen(entries))
+                client.gui.setScreen(TestPopupScreen(entries))
                 openDamnScreen = ""
             } else if (openDamnScreen == "the_big_one") {
                 ConfigApi.openScreen("fzzy_config_test")

--- a/src/testmod/kotlin/me/fzzyhmstrs/fzzy_config_test/test/TestConfigImpl3.kt
+++ b/src/testmod/kotlin/me/fzzyhmstrs/fzzy_config_test/test/TestConfigImpl3.kt
@@ -31,7 +31,7 @@ import me.fzzyhmstrs.fzzy_config_test.FC
 import me.fzzyhmstrs.fzzy_config_test.fctId
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.client.Minecraft
-import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.EntityTypes
 import net.minecraft.world.level.material.Fluids
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.storage.loot.BuiltInLootTables
@@ -99,7 +99,7 @@ class TestConfigImpl3: Config(Identifier.fromNamespaceAndPath("fzzy_config_test"
 
     private var blockTest = Blocks.AMETHYST_BLOCK
 
-    private var entityTest = EntityType.EGG
+    private var entityTest = EntityTypes.EGG
 
     private var fluidTest = Fluids.LAVA
 


### PR DESCRIPTION
Inital port for 26.2
Changes:
- Minecraft.screen -> Minecraft.gui.screen
- ChatFormatting no longer contains the text color. That has been made in to its own Class.
  - Places where `ChatFormatting.color` was used is now `TextColor.fromLegacyFormat(ChatFormatting)?.value`
  - Places where `ChatFormatting.RED.color` was uses is now `TextColor.RED.value
- `I18n.exists()` was removed. As replacement added `PortingUtils.langKeyExists()` 
- `Holder` is now a sealed class. Because of this `RegistrySupplier` no longer extends it, But all functions have been kept for convince sake.
-  For some reason `BlockTags.ACACIA_LOGS` has been deleted so It has been replaced with `BlockTags.LOGS`
- Entity Types got moved to a types class EntityType.EGG -> EntityTypes.EGG
